### PR TITLE
Fix modal styles

### DIFF
--- a/src/components/UI/Modal.js
+++ b/src/components/UI/Modal.js
@@ -14,7 +14,7 @@ const Modal = ({ children, isOpen, onClose }) => (
     onRequestClose={onClose}
   >
     <div
-      className="absolute flex h-4 items-center justify-center link-alert w-4"
+      className="absolute flex h-4 items-center justify-center link w-4"
       css={css`
         right: 10px;
         top: 10px;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,6 +1,6 @@
 @tailwind base;
 
-input, a, button:focus {
+input, a, button:focus, .ReactModal__Content:focus {
   outline: none;
 }
 


### PR DESCRIPTION
React-modal has `outline: none` by default but it is been overwritten by browser in some way. Therefore I decided to add modal class name to base stylesheet together with others.